### PR TITLE
Update luna_pinyin.custom.yaml

### DIFF
--- a/luna_pinyin.custom.yaml
+++ b/luna_pinyin.custom.yaml
@@ -1,6 +1,8 @@
 patch:
   #載入朙月拼音擴充詞庫
   'translator/dictionary': luna_pinyin.extended
+  #使 macOS 下朙月拼音候选字水平显示
+  style/horizontal: true
 
 __patch:
 # 优化的符号输入


### PR DESCRIPTION
在 macOS 环境下，修改 'default.custom.yaml' 和 'weasel.custom.yaml' 的配置均无法使鼠须管朙月拼音的候选字水平显示。需要修改 'luna_pinyin.custom.yaml' 配置中选项才可以。可否添加该选项到默认配置里？